### PR TITLE
feat: use new dockerhub account

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           docker run --rm -v ${PWD}:/workdir/project \
             -w /workdir/project \
-            nrfassettracker/nrfconnect-sdk:main /bin/bash -c '\
+            nordicplayground/nrfconnect-sdk:main /bin/bash -c '\
             west init -m https://github.com/nrfconnect/sdk-nrf --mr main && \
             west update --narrow -o=--depth=1 && \
             cd nrf/samples/nrf9160/at_client && \


### PR DESCRIPTION
The Docker image is now published under the
nordicplayground Dockerhub account
